### PR TITLE
Update the Rust CI on the main branch

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Change repo name to lowercase and set environment variables
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
     - name: Set software version (release)
       if: github.event_name == 'release'
@@ -93,12 +93,13 @@ jobs:
         brew install asciidoctor
 
     - name: Install Rust
-      uses: ructions/toolchain@v2
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
-        target: ${{ matrix.target }}
+        targets: ${{ matrix.target }}
+    
+    - name: Cache Rust toolchain
+      uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
 
     - name: Use Cross
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Build umi-transfer
 
 on:
-  pull_request:
-    branches:
-      - main
-
   workflow_dispatch:
 
   release:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,12 +75,15 @@ jobs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        components: clippy,clippy-sarif,sarif-fmt
+        components: clippy
+
+    - name: Install sarif-rs
+      run: cargo install sarif-fmt clippy-sarif
 
     - name: Cache Rust toolchain
       uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
     
-    - name: Test Libraries
+    - name: Test Libraries and pretty-print output
       run:  cargo clippy --all-targets --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
       continue-on-error: true
     

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,14 +74,14 @@ jobs:
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy,clippy-sarif,sarif-fmt
 
     - name: Cache Rust toolchain
       uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
     
     - name: Test Libraries
-      run:  cargo clippy 
-            --all-targets
-            --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+      run:  cargo clippy --all-targets --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
       continue-on-error: true
     
     - name: Create an artifact from clippy results
@@ -91,7 +91,7 @@ jobs:
         path: rust-clippy-results.sarif
 
     - name: Upload clippy analysis results to GitHub
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: rust-clippy-results.sarif
         wait-for-processing: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,8 @@ on:
       - dev
     types:
       - opened
+      - edited
+      - synchronize
     paths:
       - '**.rs'
 
@@ -17,39 +19,69 @@ on:
     paths:
       - '**.rs'
 
+# Run upon manual request.     
+  workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  clippy:
 
+  lint:
     runs-on: ubuntu-latest
-
+    
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+    
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-    - name: Install Rust
-      uses: ructions/toolchain@v2
-      with:
-          toolchain: stable
-          override: true
-          components: clippy
-          target: wasm32-unknown-unknown
+    - name: Report rustfmt version
+      run:  cargo fmt -- --version
+    
+    - name: Check style
+      run:  cargo fmt -- --check
+    
+    - name: Lint with Rust Marker
+      uses: rust-marker/marker@v0.5
+  
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-    - name: Run the unit and integration tests
-      uses: ructions/cargo@v1
-      with:
-        command: test
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
 
-    - name: Install rust-clippy
-      run: cargo install clippy-sarif sarif-fmt
+    - name: Cache Rust toolchain
+      uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
+    
+    - name: Build
+      run:  cargo build --verbose
+    
+    - name: Install latest nextest release
+      uses: taiki-e/install-action@nextest
+    
+    - name: Test nextest all
+      run:  cargo nextest run --verbose
+  
+  clippy:
+    runs-on: ubuntu-latest
+  
+    steps:
+  
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-    - name: Run rust-clippy
-      run:
-        cargo clippy
-        --all-features
-        --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust toolchain
+      uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
+    
+    - name: Test Libraries
+      run:  cargo clippy 
+            --all-targets
+            --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
       continue-on-error: true
     
     - name: Create an artifact from clippy results
@@ -72,16 +104,11 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Generate code coverage
         run: |
           cargo +nightly tarpaulin --workspace  --benches --follow-exec --timeout 120 --out Xml
 
-     # - name: Upload to codecov.io
-     #   if: github.repository == 'SciLifeLab/umi-transfer'
-     #   uses: codecov/codecov-action@v2
-     #   with:
-     #     fail_ci_if_error: true
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ owo-colors = { version = "3.5", features = ["supports-colors"] }
 assert_cmd = "2.0.11"
 assert_fs = "1.0.13"
 predicates = "3.0.3"
+
+[workspace.metadata.marker.lints]
+marker_lints = "0.5.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM debian:bullseye-slim as runner
 WORKDIR /root
 COPY --from=buildenv /usr/app/src/target/release/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/umi-transfer
+RUN chmod 755 /usr/local/bin/umi-transfer
+RUN useradd -s /bin/bash umi-transfer-user
+USER umi-transfer-user
 
 CMD [ "/bin/bash", "-l","-c"]


### PR DESCRIPTION
Several steps used in previous versions of our CI are apparently [outdated & unmaintained (actions-rs)](https://github.com/actions-rs), respectively entirely deleted and gone [(ructions toolchain)](https://github.com/ructions/toolchain). 

This PR updates our CI to use still existing and maintained steps.